### PR TITLE
ili934x.cpp - fix: Add include pico/time.h for fixing the build.

### DIFF
--- a/src/common/ili934x/ili934x.cpp
+++ b/src/common/ili934x/ili934x.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "stdio.h"
 #include "ili934x.h"
 #include "hardware/gpio.h"
+#include "pico/time.h"
 #include <cstring>
 
 #ifndef pgm_read_byte


### PR DESCRIPTION
After cloning the project and setting the includes correctly, the library was found, but it wasn’t able to build due to the following error:

$HOME/pico/pico-libs/src/common/ili934x/ili934x.cpp: In member function 'void ILI934X::reset()':
$HOME/pico/pico-libs/src/common/ili934x/ili934x.cpp:69:5: error: 'sleep_us' was not declared in this scope
   69 |     sleep_us(30);
      |     ^~~~~~~~
$HOME/pico/pico-libs/src/common/ili934x/ili934x.cpp: In member function 'void ILI934X::_write(uint8_t, uint8_t*, size_t)':
$HOME/pico/pico-libs/src/common/ili934x/ili934x.cpp:445:9: error: 'sleep_us' was not declared in this scope
  445 |         sleep_us(1);

After including pico/time.h in the file, the build was successful.